### PR TITLE
[MOSIP-42453]: Reject Face Image if Not in 24-bit RGB Format

### DIFF
--- a/mosip-compliance-toolkit/Dockerfile
+++ b/mosip-compliance-toolkit/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin:11-jre-focal
 
  ARG SOURCE
 ARG COMMIT_HASH

--- a/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/validators/ISOStandardsValidator.java
+++ b/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/validators/ISOStandardsValidator.java
@@ -1752,7 +1752,7 @@ public class ISOStandardsValidator extends SBIValidator {
 			if (!FaceISOStandardsValidator.getInstance().isValidImageCompressionType(purpose, compressionType,
 					decoderRequestDto)) {
 				message.append(
-						"<BR>Invalid Image Compression Type for Finger Modality, expected values[Purpose(Auth), ({JPEG_2000_LOSSY(0x01)}), Purpose(Registration), ({JPEG_2000_LOSS_LESS(0x02)})], but received input value[Purpose("
+						"<BR>Invalid Image Compression Type for Face Modality, expected values[Purpose(Auth), ({JPEG_2000_LOSSY(0x01)}), Purpose(Registration), ({JPEG_2000_LOSS_LESS(0x02)})], but received input value[Purpose("
 								+ purpose + "), (" + String.format("0x%02X", compressionType) + ")]");
 				code.append(AppConstants.COMMA_SEPARATOR);
 				code.append("ISO_VALIDATOR_108");

--- a/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/validators/ISOStandardsValidator.java
+++ b/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/validators/ISOStandardsValidator.java
@@ -1867,10 +1867,17 @@ public class ISOStandardsValidator extends SBIValidator {
 				isValidWarnings = true;
 			}
 			if (!FaceISOStandardsValidator.getInstance().isValidImageColorSpace(purpose, Modality.Face, decoderRequestDto)) {
-				warningMessage.append(
-						"<BR>Invalid Image Color Space allowed values Up to RGB[24 bit]");
-				warningMsgCode.append("ISO_WARNING_012");
-				isValidWarnings = true;
+				message.append(
+						"<BR>Invalid Image Color Space for Face Modality, expected RGB[24 bit], but received colorSpace["
+								+ decoderRequestDto.getImageColorSpace() + "], depth[" + decoderRequestDto.getDepth()
+								+ "]");
+				code.append(AppConstants.COMMA_SEPARATOR);
+				code.append("ISO_VALIDATOR_118");
+				code.append(AppConstants.ARGUMENTS_DELIMITER);
+				code.append(decoderRequestDto.getImageColorSpace());
+				code.append(AppConstants.ARGUMENTS_SEPARATOR);
+				code.append(decoderRequestDto.getDepth());
+				isValid = false;
 			}
 			if (!FaceISOStandardsValidator.getInstance().isValidImageDPI(purpose, Modality.Face, decoderRequestDto)) {
 				warningMessage.append(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Face image validation so invalid color space now fails validation outright rather than showing a warning, strengthening enforcement of required color space settings.
  * Corrected the Face compression-type validation message to accurately reference Face modality.
* **Chores**
  * Updated the Docker runtime base image to use a maintained Java 11 JRE distribution, with no functional changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->