### PR TITLE
Add DB upgrade/rollback scripts for 1.4.0->1.4.1->1.4.2->1.4.3

### DIFF
--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.0_to_1.4.1_rollback.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.0_to_1.4.1_rollback.sql
@@ -1,0 +1,1 @@
+\echo 'Rollback Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'

--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.0_to_1.4.1_upgrade.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.0_to_1.4.1_upgrade.sql
@@ -1,0 +1,1 @@
+\echo 'Upgrade Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'

--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.1_to_1.4.2_rollback.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.1_to_1.4.2_rollback.sql
@@ -1,0 +1,1 @@
+\echo 'Rollback Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'

--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.1_to_1.4.2_upgrade.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.1_to_1.4.2_upgrade.sql
@@ -1,0 +1,1 @@
+\echo 'Upgrade Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'

--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.2_to_1.4.3_rollback.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.2_to_1.4.3_rollback.sql
@@ -1,0 +1,1 @@
+\echo 'Rollback Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'

--- a/db_upgrade_scripts/mosip_toolkit/sql/1.4.2_to_1.4.3_upgrade.sql
+++ b/db_upgrade_scripts/mosip_toolkit/sql/1.4.2_to_1.4.3_upgrade.sql
@@ -1,0 +1,1 @@
+\echo 'Upgrade Queries not required for transition from $CURRENT_VERSION to $UPGRADE_VERSION'


### PR DESCRIPTION
No schema changes required for these transitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added clear informational messages to database upgrade scripts when no SQL changes are required for the specified version transitions.
  - Added clear informational messages to corresponding rollback scripts indicating rollback queries are not needed for those transitions.
  - Improved visibility during upgrades/rollbacks by emitting `psql` notices/echo output during the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->