### PR TITLE
Fix new SonarQube code smells (S3024, S112, S1155) in service layer

### DIFF
--- a/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/BiometricTestDataService.java
+++ b/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/BiometricTestDataService.java
@@ -821,10 +821,10 @@ public class BiometricTestDataService {
                 List<List<ValidatorDef>> validatorDefsList = testCaseDto.getValidatorDefs();
                 for (int i = 0; i < validatorDefsList.size(); i++) {
                     if (testCaseDto.getMethodName().size() > i) {
-                        builder.append("Validators for " + testCaseDto.getMethodName().get(i) + "\n");
+                        builder.append("Validators for ").append(testCaseDto.getMethodName().get(i)).append("\n");
                         for (ValidatorDef validatorDef : validatorDefsList.get(i)) {
-                            builder.append("Name - " + validatorDef.getName() + "\n");
-                            builder.append("Description - " + validatorDef.getDescription() + "\n");
+                            builder.append("Name - ").append(validatorDef.getName()).append("\n");
+                            builder.append("Description - ").append(validatorDef.getDescription()).append("\n");
                         }
                         builder.append("\n");
                     }

--- a/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/ReportService.java
+++ b/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/ReportService.java
@@ -733,10 +733,10 @@ public class ReportService {
 		return validationResult;
 	}
 
-	private PartnerTable getPartnerDetails(String projectId) throws Exception {
+	private PartnerTable getPartnerDetails(String projectId) throws IOException {
 		PartnerTable partnerTable = new PartnerTable();
 		PartnerDetailsDto partnerDetailsDto = partnerManagerHelper.getPartnerDetails(projectId);
-		if (partnerDetailsDto != null && partnerDetailsDto.getErrors().size() == 0) {
+		if (partnerDetailsDto != null && partnerDetailsDto.getErrors().isEmpty()) {
 			Partner partner = partnerDetailsDto.getResponse();
 			partnerTable.setOrgName(partner.getOrganizationName());
 			partnerTable.setAddress(partner.getAddress());

--- a/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/SbiProjectService.java
+++ b/mosip-compliance-toolkit/src/main/java/io/mosip/compliance/toolkit/service/SbiProjectService.java
@@ -431,7 +431,7 @@ public class SbiProjectService {
 		try {
 			EncryptionKeyResponseDto keyManagerResponseDto = keyManagerHelper.getCertificate();
 
-			if ((keyManagerResponseDto.getErrors() != null && keyManagerResponseDto.getErrors().size() > 0)) {
+			if ((keyManagerResponseDto.getErrors() != null && !keyManagerResponseDto.getErrors().isEmpty())) {
 				keyManagerResponseDto.getErrors().get(0).getMessage();
 				throw new ToolkitException(ToolkitErrorCodes.ENCRYPTION_KEY_ERROR.getErrorCode(),
 						keyManagerResponseDto.getErrors().get(0).getMessage());


### PR DESCRIPTION
Use StringBuilder.append chaining instead of string-concat append calls, narrow a generic Exception throw to the actual IOException, and use isEmpty() instead of size() comparisons.